### PR TITLE
S11 agregar provincia y redux reset on logout

### DIFF
--- a/src/actions/AuthActions.js
+++ b/src/actions/AuthActions.js
@@ -8,7 +8,7 @@ import {
   ON_LOGIN_SUCCESS,
   ON_LOGIN_FAIL,
   ON_LOGOUT,
-  // ON_LOGOUT_SUCCESS,
+  ON_LOGOUT_SUCCESS,
   ON_LOGIN_FACEBOOK,
   ON_LOGIN_GOOGLE,
   ON_EMAIL_VERIFY_ASKED,
@@ -157,7 +157,7 @@ export const onLogout = (commerceId, workplaces) => async dispatch => {
     firebase
       .auth()
       .signOut()
-      .then(() => dispatch({ type: 'ON_LOGOUT_SUCCESS' })) //tira error cuando uso la variable importada
+      .then(() => dispatch({ type: ON_LOGOUT_SUCCESS })) //tira error cuando uso la variable importada
       .catch(() => dispatch({ type: ON_LOGIN_FAIL }));
   } catch (error) {
     return dispatch => dispatch({ type: ON_LOGIN_FAIL });

--- a/src/actions/AuthActions.js
+++ b/src/actions/AuthActions.js
@@ -8,7 +8,7 @@ import {
   ON_LOGIN_SUCCESS,
   ON_LOGIN_FAIL,
   ON_LOGOUT,
-  ON_LOGOUT_SUCCESS,
+  // ON_LOGOUT_SUCCESS,
   ON_LOGIN_FACEBOOK,
   ON_LOGIN_GOOGLE,
   ON_EMAIL_VERIFY_ASKED,
@@ -157,9 +157,7 @@ export const onLogout = (commerceId, workplaces) => async dispatch => {
     firebase
       .auth()
       .signOut()
-      .then(() => {
-        dispatch({ type: ON_LOGOUT_SUCCESS });
-      })
+      .then(() => dispatch({ type: 'ON_LOGOUT_SUCCESS' })) //tira error cuando uso la variable importada
       .catch(() => dispatch({ type: ON_LOGIN_FAIL }));
   } catch (error) {
     return dispatch => dispatch({ type: ON_LOGIN_FAIL });

--- a/src/actions/ClientDataActions.js
+++ b/src/actions/ClientDataActions.js
@@ -31,7 +31,7 @@ export const onRegisterFormOpen = () => {
   return { type: ON_REGISTER_FORM_OPEN };
 };
 
-export const onUserRegister = ({ email, password, firstName, lastName, phone }) => {
+export const onUserRegister = ({ email, password, firstName, lastName, phone, province }) => {
   return dispatch => {
     dispatch({ type: ON_USER_REGISTER });
 
@@ -48,7 +48,7 @@ export const onUserRegister = ({ email, password, firstName, lastName, phone }) 
             lastName,
             email,
             phone,
-            province: { provinceId: '', name: '' },
+            province,
             commerceId: null,
             softDelete: null
           })

--- a/src/actions/ClientDataActions.js
+++ b/src/actions/ClientDataActions.js
@@ -48,6 +48,7 @@ export const onUserRegister = ({ email, password, firstName, lastName, phone }) 
             lastName,
             email,
             phone,
+            province: { provinceId: '', name: '' },
             commerceId: null,
             softDelete: null
           })
@@ -80,7 +81,7 @@ export const onUserRead = (clientId = firebase.auth().currentUser.uid) => {
   };
 };
 
-export const onUserUpdate = ({ firstName, lastName, phone, profilePicture }) => async dispatch => {
+export const onUserUpdate = ({ firstName, lastName, phone, province, profilePicture }) => async dispatch => {
   dispatch({ type: ON_USER_UPDATING });
 
   const { currentUser } = firebase.auth();
@@ -105,6 +106,7 @@ export const onUserUpdate = ({ firstName, lastName, phone, profilePicture }) => 
         firstName,
         lastName,
         phone,
+        province,
         profilePicture: url ? url : profilePicture
       });
 

--- a/src/components/client/ClientProfile.js
+++ b/src/components/client/ClientProfile.js
@@ -6,10 +6,10 @@ import * as Permissions from 'expo-permissions';
 import Constants from 'expo-constants';
 import { connect } from 'react-redux';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
-import { CardSection, Input, Spinner, Menu, MenuItem, IconButton, Toast } from '../common';
+import { CardSection, Input, Spinner, Menu, MenuItem, IconButton, Toast, Picker } from '../common';
 import { MAIN_COLOR } from '../../constants';
 import { imageToBlob, validateValueType, trimString } from '../../utils';
-import { onUserRead, onUserUpdate, onClientDataValueChange } from '../../actions';
+import { onUserRead, onUserUpdate, onClientDataValueChange, onProvincesIdRead } from '../../actions';
 
 class ClientProfile extends Component {
   state = {
@@ -19,7 +19,8 @@ class ClientProfile extends Component {
     stateBeforeChanges: null,
     firstNameError: '',
     lastNameError: '',
-    phoneError: ''
+    phoneError: '',
+    pickerPlaceholder: { value: '', label: 'Seleccionar...' }
   };
 
   static navigationOptions = ({ navigation }) => {
@@ -32,6 +33,7 @@ class ClientProfile extends Component {
 
   componentDidMount() {
     this.props.navigation.setParams({ rightIcon: this.renderEditButton() });
+    this.props.onProvincesIdRead();
   }
 
   renderEditButton = () => {
@@ -61,11 +63,11 @@ class ClientProfile extends Component {
   onSavePress = async () => {
     try {
       if (this.validateMinimumData()) {
-        let { firstName, lastName, phone, profilePicture } = this.props;
+        let { firstName, lastName, phone, profilePicture, province } = this.props;
 
         if (this.state.newProfilePicture) profilePicture = await imageToBlob(profilePicture);
 
-        this.props.onUserUpdate({ firstName, lastName, phone, profilePicture });
+        this.props.onUserUpdate({ firstName, lastName, phone, province, profilePicture });
         this.disableEdit();
       }
     } catch (error) {
@@ -232,6 +234,13 @@ class ClientProfile extends Component {
     return this.renderFirstNameError() && this.renderLastNameError() && this.renderPhoneError();
   };
 
+  onProvincePickerChange = value => {
+    if (value) {
+      var { value, label } = this.props.provincesList.find(province => province.value == value);
+      this.props.onClientDataValueChange({ province: { provinceId: value, name: label } });
+    }
+  };
+
   render() {
     if (this.props.loading) return <Spinner />;
 
@@ -312,6 +321,16 @@ class ClientProfile extends Component {
             />
           </CardSection>
           <CardSection>
+            <Picker
+              title="Provincia:"
+              placeholder={this.state.pickerPlaceholder}
+              items={this.props.provincesList}
+              value={this.props.province.provinceId}
+              disabled={!this.state.editEnabled}
+              onValueChange={value => this.onProvincePickerChange(value)}
+            />
+          </CardSection>
+          <CardSection>
             <Input label="E-Mail:" value={this.props.email} editable={false} />
           </CardSection>
         </View>
@@ -373,23 +392,39 @@ const {
 });
 
 const mapStateToProps = state => {
-  const { clientId, firstName, lastName, phone, email, profilePicture, rating, loading, refreshing } = state.clientData;
+  const {
+    clientId,
+    firstName,
+    lastName,
+    phone,
+    province,
+    email,
+    profilePicture,
+    rating,
+    loading,
+    refreshing
+  } = state.clientData;
 
   const { city, provinceName } = state.locationData.userLocation;
+  const { provincesList } = state.provinceData;
 
   return {
     clientId,
     firstName,
     lastName,
     phone,
+    province,
     email,
     profilePicture,
     rating,
     loading,
     refreshing,
     city,
-    provinceName
+    provinceName,
+    provincesList
   };
 };
 
-export default connect(mapStateToProps, { onUserRead, onUserUpdate, onClientDataValueChange })(ClientProfile);
+export default connect(mapStateToProps, { onUserRead, onUserUpdate, onClientDataValueChange, onProvincesIdRead })(
+  ClientProfile
+);

--- a/src/components/client/ClientProfile.js
+++ b/src/components/client/ClientProfile.js
@@ -236,7 +236,7 @@ class ClientProfile extends Component {
 
   onProvincePickerChange = value => {
     if (value) {
-      var { value, label } = this.props.provincesList.find(province => province.value == value);
+      var { value, label } = this.props.provincesList.find(province => province.value === value);
       this.props.onClientDataValueChange({ province: { provinceId: value, name: label } });
     }
   };

--- a/src/components/client/CommercesFiltersMap.js
+++ b/src/components/client/CommercesFiltersMap.js
@@ -16,7 +16,10 @@ class CommercesFiltersMap extends Component {
   };
 
   componentDidMount() {
-    this.props.navigation.setParams({ onApplyFiltersPress: this.onApplyFiltersPress, onCancelPress: this.onCancelPress });
+    this.props.navigation.setParams({
+      onApplyFiltersPress: this.onApplyFiltersPress,
+      onCancelPress: this.onCancelPress
+    });
     this.setState({ selectedLocationBeforechanges: this.props.selectedLocation });
   }
 
@@ -40,9 +43,7 @@ class CommercesFiltersMap extends Component {
   }
 }
 
-const { windowContainerStyle } = StyleSheet.create({
-  windowContainerStyle: { flex: 1 }
-});
+const { windowContainerStyle } = StyleSheet.create({ windowContainerStyle: { flex: 1 } });
 
 const mapStateToProps = state => {
   const { selectedLocation } = state.locationData;

--- a/src/components/client/CommercesList.js
+++ b/src/components/client/CommercesList.js
@@ -11,7 +11,7 @@ import getEnvVars from '../../../environment';
 import ConnectedHits from './CommercesList.SearchHits';
 import ConnectedSearchBox from './CommercesList.SearchBox';
 import ConnectedStateResults from './CommercesList.StateResults';
-import { onFavoriteCommercesRead, onCommercesListValueChange, onLocationValueChange } from '../../actions';
+import { onFavoriteCommercesRead, onCommercesListValueChange, onSelectedLocationChange } from '../../actions';
 
 const { appId, searchApiKey, commercesIndex } = getEnvVars().algoliaConfig;
 
@@ -34,10 +34,7 @@ class CommercesList extends Component {
     };
   };
 
-  state = {
-    areaName: this.props.navigation.state.params.areaName,
-    searchVisible: false
-  };
+  state = { areaName: this.props.navigation.state.params.areaName, searchVisible: false };
 
   componentDidMount() {
     this.props.navigation.setParams({
@@ -57,8 +54,11 @@ class CommercesList extends Component {
   }
 
   onFiltersClear = () => {
-    this.props.onCommercesListValueChange({ provinceNameFilter: '', locationRadiusKms: '' });
-    this.props.onLocationValueChange({ selectedLocation: {} });
+    this.props.onCommercesListValueChange({
+      locationButtonIndex: 0,
+      provinceNameFilter: this.props.provinceClientName ? this.props.provinceClientName : ''
+    });
+    this.props.onSelectedLocationChange();
   };
 
   onSearchPress = () => {
@@ -83,9 +83,7 @@ class CommercesList extends Component {
 
   obtainFacetProps = () => {
     if (this.state.areaName && this.props.provinceNameFilter)
-      return {
-        filters: `areaName:\'${this.state.areaName}\' AND provinceName:\'${this.props.provinceNameFilter}\'`
-      };
+      return { filters: `areaName:\'${this.state.areaName}\' AND provinceName:\'${this.props.provinceNameFilter}\'` };
     else if (this.state.areaName) return { filters: `areaName:\'${this.state.areaName}\'` };
     else if (this.props.provinceNameFilter) return { filters: `provinceName:\'${this.props.provinceNameFilter}\'` };
     else return null;
@@ -123,7 +121,6 @@ class CommercesList extends Component {
 
 const mapStateToProps = state => {
   const { refinement, favoriteCommerces, provinceNameFilter, locationRadiusKms } = state.commercesList;
-
   const { address, city, provinceName, country, latitude, longitude, selectedLocation } = state.locationData;
 
   return {
@@ -145,5 +142,5 @@ const mapStateToProps = state => {
 export default connect(mapStateToProps, {
   onFavoriteCommercesRead,
   onCommercesListValueChange,
-  onLocationValueChange
+  onSelectedLocationChange
 })(CommercesList);

--- a/src/components/client/CommercesList.js
+++ b/src/components/client/CommercesList.js
@@ -47,6 +47,9 @@ class CommercesList extends Component {
     });
 
     this.props.onFavoriteCommercesRead();
+    if (this.props.provinceNameFilter == null) {
+      this.props.onCommercesListValueChange({ provinceNameFilter: this.props.provinceClientName });
+    }
   }
 
   componentWillUnmount() {
@@ -134,7 +137,8 @@ const mapStateToProps = state => {
     country,
     latitude,
     longitude,
-    selectedLocation
+    selectedLocation,
+    provinceClientName: state.clientData.province.name
   };
 };
 

--- a/src/components/client/CommercesList.js
+++ b/src/components/client/CommercesList.js
@@ -44,8 +44,8 @@ class CommercesList extends Component {
     });
 
     this.props.onFavoriteCommercesRead();
-    if (this.props.provinceNameFilter == null) {
-      this.props.onCommercesListValueChange({ provinceNameFilter: this.props.provinceClientName });
+    if (!this.props.provinceNameFilter) {
+      this.props.onCommercesListValueChange({ provinceNameFilter: this.props.clientProvinceName });
     }
   }
 
@@ -56,7 +56,7 @@ class CommercesList extends Component {
   onFiltersClear = () => {
     this.props.onCommercesListValueChange({
       locationButtonIndex: 0,
-      provinceNameFilter: this.props.provinceClientName ? this.props.provinceClientName : ''
+      provinceNameFilter: this.props.clientProvinceName ? this.props.clientProvinceName : ''
     });
     this.props.onSelectedLocationChange();
   };
@@ -135,7 +135,7 @@ const mapStateToProps = state => {
     latitude,
     longitude,
     selectedLocation,
-    provinceClientName: state.clientData.province.name
+    clientProvinceName: state.clientData.province.name
   };
 };
 

--- a/src/components/client/RegisterForm.js
+++ b/src/components/client/RegisterForm.js
@@ -2,8 +2,8 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { View } from 'react-native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
-import { CardSection, Button, Input } from '../common';
-import { onClientDataValueChange, onUserRegister, onRegisterFormOpen } from '../../actions';
+import { CardSection, Button, Input, Picker } from '../common';
+import { onClientDataValueChange, onUserRegister, onRegisterFormOpen, onProvincesIdRead } from '../../actions';
 import { validateValueType, trimString } from '../../utils';
 
 class RegisterForm extends Component {
@@ -13,11 +13,13 @@ class RegisterForm extends Component {
     confirmPasswordError: '',
     firstNameError: '',
     lastNameError: '',
-    phoneError: ''
+    phoneError: '',
+    pickerPlaceholder: { value: '', label: 'Seleccionar...' }
   };
 
   componentDidMount() {
     this.props.onRegisterFormOpen();
+    this.props.onProvincesIdRead();
   }
 
   onButtonPressHandler = () => {
@@ -27,7 +29,8 @@ class RegisterForm extends Component {
         password: this.props.password,
         firstName: this.props.firstName,
         lastName: this.props.lastName,
-        phone: this.props.phone
+        phone: this.props.phone,
+        province: this.props.province
       });
     }
   };
@@ -115,6 +118,13 @@ class RegisterForm extends Component {
     } else {
       this.setState({ phoneError: '' });
       return true;
+    }
+  };
+
+  onProvincePickerChange = value => {
+    if (value) {
+      var { value, label } = this.props.provincesList.find(province => province.value === value);
+      this.props.onClientDataValueChange({ province: { provinceId: value, name: label } });
     }
   };
 
@@ -210,6 +220,15 @@ class RegisterForm extends Component {
             />
           </CardSection>
           <CardSection>
+            <Picker
+              title="Provincia:"
+              placeholder={this.state.pickerPlaceholder}
+              items={this.props.provincesList}
+              value={this.props.province.provinceId}
+              onValueChange={value => this.onProvincePickerChange(value)}
+            />
+          </CardSection>
+          <CardSection>
             <Button title="Confirmar" loading={this.props.loading} onPress={this.onButtonPressHandler} />
           </CardSection>
         </View>
@@ -219,7 +238,8 @@ class RegisterForm extends Component {
 }
 
 const mapStateToProps = state => {
-  const { email, password, confirmPassword, firstName, lastName, phone, loading, error } = state.clientData;
+  const { email, password, confirmPassword, firstName, lastName, phone, province, loading, error } = state.clientData;
+  const { provincesList } = state.provinceData;
 
   return {
     email,
@@ -228,13 +248,16 @@ const mapStateToProps = state => {
     firstName,
     lastName,
     phone,
+    province,
     loading,
-    error
+    error,
+    provincesList
   };
 };
 
 export default connect(mapStateToProps, {
   onClientDataValueChange,
   onUserRegister,
-  onRegisterFormOpen
+  onRegisterFormOpen,
+  onProvincesIdRead
 })(RegisterForm);

--- a/src/components/commerce/CommerceProfile.js
+++ b/src/components/commerce/CommerceProfile.js
@@ -274,7 +274,7 @@ class CommerceProfile extends Component {
 
   onProvincePickerChange = value => {
     if (value) {
-      var { value, label } = this.props.provincesList.find(province => province.value == value);
+      var { value, label } = this.props.provincesList.find(province => province.value === value);
       this.props.onCommerceValueChange({ province: { provinceId: value, name: label } });
       this.props.onLocationValueChange({ provinceName: label });
     }

--- a/src/components/commerce/CommerceProfile.js
+++ b/src/components/commerce/CommerceProfile.js
@@ -275,9 +275,7 @@ class CommerceProfile extends Component {
   onProvincePickerChange = value => {
     if (value) {
       var { value, label } = this.props.provincesList.find(province => province.value == value);
-      this.props.onCommerceValueChange({
-        province: { provinceId: value, name: label }
-      });
+      this.props.onCommerceValueChange({ province: { provinceId: value, name: label } });
       this.props.onLocationValueChange({ provinceName: label });
     }
   };

--- a/src/reducers/AuthReducer.js
+++ b/src/reducers/AuthReducer.js
@@ -4,7 +4,6 @@ import {
   ON_LOGIN_SUCCESS,
   ON_LOGIN_FAIL,
   ON_LOGOUT,
-  ON_LOGOUT_SUCCESS,
   ON_LOGOUT_FAIL,
   ON_LOGIN_FACEBOOK,
   ON_LOGIN_GOOGLE,
@@ -53,7 +52,6 @@ export default (state = INITIAL_STATE, action) => {
       return { ...INITIAL_STATE, loadingGoogle: true };
 
     case ON_LOGIN_SUCCESS:
-    case ON_LOGOUT_SUCCESS:
     case ON_LOGOUT_FAIL:
     case ON_REAUTH_SUCCESS:
       return { ...INITIAL_STATE };

--- a/src/reducers/ClientDataReducer.js
+++ b/src/reducers/ClientDataReducer.js
@@ -28,6 +28,7 @@ const INITIAL_STATE = {
   firstName: '',
   lastName: '',
   phone: '',
+  province: { provinceId: '', name: '' },
   commerceId: null,
   rating: { total: 0, count: 0 },
   loading: false,

--- a/src/reducers/CommercesListReducer.js
+++ b/src/reducers/CommercesListReducer.js
@@ -14,7 +14,7 @@ const INITIAL_STATE = {
   loading: false,
   searching: true,
   areas: [],
-  provinceNameFilter: '',
+  provinceNameFilter: null,
   locationButtonIndex: 0,
   locationRadiusKms: 5,
   markers: []

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,5 +1,5 @@
 import { combineReducers, createStore, applyMiddleware } from 'redux';
-// import { ON_LOGOUT_SUCCESS } from '../actions';
+import { ON_LOGOUT_SUCCESS } from '../actions/types';
 import ReduxThunk from 'redux-thunk';
 import ServiceFormReducer from './ServiceFormReducer';
 import ServicesListReducer from './ServicesListReducer';
@@ -56,7 +56,7 @@ const reducers = combineReducers({
 });
 
 const rootReducer = (state, action) => {
-  if (action.type === 'ON_LOGOUT_SUCCESS') {
+  if (action.type === ON_LOGOUT_SUCCESS) {
     state = undefined;
   }
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,4 +1,5 @@
 import { combineReducers, createStore, applyMiddleware } from 'redux';
+// import { ON_LOGOUT_SUCCESS } from '../actions';
 import ReduxThunk from 'redux-thunk';
 import ServiceFormReducer from './ServiceFormReducer';
 import ServicesListReducer from './ServicesListReducer';
@@ -54,4 +55,11 @@ const reducers = combineReducers({
   paymentData: PaymentDataReducer
 });
 
-export default createStore(reducers, {}, applyMiddleware(ReduxThunk));
+const rootReducer = (state, action) => {
+  if (action.type === 'ON_LOGOUT_SUCCESS') {
+    state = undefined;
+  }
+
+  return reducers(state, action);
+};
+export default createStore(rootReducer, {}, applyMiddleware(ReduxThunk));


### PR DESCRIPTION
Se agrega un campo más en los datos del cliente (Provincia). Esto es para que todo usuario que tenga una provincia seteada, se le va a filtrar por default los negocios de esa misma ciudad
- Cuando se hagan cambios en los filtros, y luego se vuelva al inicio de la búsqueda (listado de rubros), los filtros se resetean al default (con el filtrado de provincia del cliente si tuviese)

PD: agregué una lógica para resetear todos los reducer de redux al desloguearse. La lógica es poner el `state` en `undefined` porque los reducer cada vez que reciban un `state` en `undefined` le setean el `INITIAL_STATE` (por eso se hace `export default (state = INITIAL_STATE, action)` en cada reducer).