### PR TITLE
Load on scroll

### DIFF
--- a/src/actions/ClientReservationsListActions.js
+++ b/src/actions/ClientReservationsListActions.js
@@ -21,7 +21,7 @@ export const onClientReservationsListRead = () => dispatch => {
     .collection(`Profiles/${currentUser.uid}/Reservations`)
     .where('cancellationDate', '==', null)
     .orderBy('startDate', 'desc')
-    .limit(50) // lo puse por ahora para no buscar todas al pedo, habria que ver de ir cargando mas a medida que se scrollea
+    .limit(20) // lo puse por ahora para no buscar todas al pedo, habria que ver de ir cargando mas a medida que se scrollea
     .onSnapshot(snapshot => {
       const reservations = [];
 
@@ -31,9 +31,7 @@ export const onClientReservationsListRead = () => dispatch => {
 
       snapshot.forEach(async res => {
         const { commerceId, areaId, serviceId, employeeId, courtId } = res.data();
-        let service,
-          employee,
-          court = null;
+        let service, employee, court = null;
 
         try {
           const commerce = await db.doc(`Commerces/${commerceId}`).get();

--- a/src/actions/ClientReviewsListActions.js
+++ b/src/actions/ClientReviewsListActions.js
@@ -2,20 +2,24 @@ import firebase from 'firebase/app';
 import 'firebase/firestore';
 import { ON_CLIENT_REVIEWS_READING, ON_CLIENT_REVIEWS_READ, ON_CLIENT_REVIEWS_READ_FAIL } from './types';
 
-export const onClientReviewsRead = clientId => dispatch => {
-  dispatch({ type: ON_CLIENT_REVIEWS_READING });
+export const onClientReviewsRead = (clientId, lastVisible = null) => dispatch => {
+  dispatch({ type: ON_CLIENT_REVIEWS_READING, payload: lastVisible ? 'refreshing' : 'loading' });
 
   const db = firebase.firestore();
   let reviews = [];
 
-  db.collection(`Profiles/${clientId}/Reviews`)
+  let query = db.collection(`Profiles/${clientId}/Reviews`)
     .where('softDelete', '==', null)
-    .orderBy('date', 'desc')
-    .limit(50)
+    .orderBy('date', 'desc');
+
+  if (lastVisible) query = query.startAfter(lastVisible);
+
+  query
+    .limit(12)
     .get()
     .then(querySnapshot => {
       querySnapshot.forEach(doc => reviews.push({ ...doc.data(), id: doc.id }));
-      dispatch({ type: ON_CLIENT_REVIEWS_READ, payload: reviews });
+      dispatch({ type: ON_CLIENT_REVIEWS_READ, payload: { reviews, firstRead: !lastVisible } });
     })
     .catch(() => dispatch({ type: ON_CLIENT_REVIEWS_READ_FAIL }));
 };

--- a/src/actions/CommerceReviewsListActions.js
+++ b/src/actions/CommerceReviewsListActions.js
@@ -2,20 +2,24 @@ import firebase from 'firebase/app';
 import 'firebase/firestore';
 import { ON_COMMERCE_REVIEWS_READING, ON_COMMERCE_REVIEWS_READ, ON_COMMERCE_REVIEWS_READ_FAIL } from './types';
 
-export const onCommerceReviewsRead = commerceId => dispatch => {
-  dispatch({ type: ON_COMMERCE_REVIEWS_READING });
+export const onCommerceReviewsRead = (commerceId, lastVisible = null) => dispatch => {
+  dispatch({ type: ON_COMMERCE_REVIEWS_READING, payload: lastVisible ? 'refreshing' : 'loading' });
 
   const db = firebase.firestore();
   let reviews = [];
 
-  db.collection(`Commerces/${commerceId}/Reviews`)
+  let query = db.collection(`Commerces/${commerceId}/Reviews`)
     .where('softDelete', '==', null)
-    .orderBy('date', 'desc')
-    .limit(50)
+    .orderBy('date', 'desc');
+
+  if (lastVisible) query = query.startAfter(lastVisible);
+
+  query
+    .limit(12)
     .get()
     .then(querySnapshot => {
       querySnapshot.forEach(doc => reviews.push({ ...doc.data(), id: doc.id }));
-      dispatch({ type: ON_COMMERCE_REVIEWS_READ, payload: reviews });
+      dispatch({ type: ON_COMMERCE_REVIEWS_READ, payload: { reviews, firstRead: !lastVisible } });
     })
     .catch(() => dispatch({ type: ON_COMMERCE_REVIEWS_READ_FAIL }));
 };

--- a/src/components/ClientReviewsList.js
+++ b/src/components/ClientReviewsList.js
@@ -1,13 +1,41 @@
 import React, { Component } from 'react';
 import { FlatList } from 'react-native';
 import { connect } from 'react-redux';
-import { Spinner, EmptyList, ReviewItem } from './common';
+import { Spinner, EmptyList, ReviewItem, Button } from './common';
 import { onClientReviewsRead } from '../actions';
 
 class ClientReviewsList extends Component {
+  state = { lastVisible: null };
+
   componentDidMount() {
     const clientId = this.props.navigation.getParam('clientId');
     this.props.onClientReviewsRead(clientId);
+  }
+
+  componentDidUpdate(prevProps) {
+    const { clientReviews, loading, refreshing } = this.props;
+
+    if (clientReviews.length && ((prevProps.loading && !loading) || (prevProps.refreshing && !refreshing))) {
+      this.setState({ lastVisible: clientReviews[clientReviews.length - 1].date.toDate() });
+    }
+  }
+
+  loadMoreReviews = () => {
+    this.props.onClientReviewsRead(this.props.navigation.state.params.clientId, this.state.lastVisible)
+  }
+
+  renderFooter = () => {
+    if (this.props.moreData)
+      return (
+        <Button
+          title='Cargar más'
+          type='clear'
+          loading={this.props.refreshing}
+          onPress={this.loadMoreReviews}
+        />
+      )
+
+    return null;
   }
 
   renderItem = ({ item }) => {
@@ -15,19 +43,26 @@ class ClientReviewsList extends Component {
   };
 
   render() {
-    return this.props.loading ? (
-      <Spinner />
-    ) : this.props.clientReviews && this.props.clientReviews.length ? (
-      <FlatList data={this.props.clientReviews} renderItem={this.renderItem} keyExtractor={review => review.id} />
-    ) : (
-      <EmptyList title="Parece que no hay reseñas" />
-    );
+    if (this.props.loading) return <Spinner />;
+
+    if (this.props.clientReviews && this.props.clientReviews.length)
+      return (
+        <FlatList
+          data={this.props.clientReviews}
+          renderItem={this.renderItem}
+          keyExtractor={review => review.id}
+          ListFooterComponent={this.renderFooter()}
+          refreshing={this.props.refreshing}
+        />
+      )
+
+    return <EmptyList title="Parece que no hay reseñas" />
   }
 }
 
 const mapStateToProps = state => {
-  const { loading, clientReviews } = state.clientReviewsList;
-  return { loading, clientReviews };
+  const { loading, clientReviews, refreshing, moreData } = state.clientReviewsList;
+  return { loading, clientReviews, refreshing, moreData };
 };
 
 export default connect(mapStateToProps, { onClientReviewsRead })(ClientReviewsList);

--- a/src/components/CommerceReviewsList.js
+++ b/src/components/CommerceReviewsList.js
@@ -1,13 +1,41 @@
 import React, { Component } from 'react';
 import { FlatList } from 'react-native';
 import { connect } from 'react-redux';
-import { Spinner, EmptyList, ReviewItem } from './common';
+import { Spinner, EmptyList, ReviewItem, Button } from './common';
 import { onCommerceReviewsRead } from '../actions';
 
 class CommerceReviewsList extends Component {
+  state = { lastVisible: null };
+
   componentDidMount() {
     const commerceId = this.props.navigation.getParam('commerceId');
     this.props.onCommerceReviewsRead(commerceId);
+  }
+
+  componentDidUpdate(prevProps) {
+    const { commerceReviews, loading, refreshing } = this.props;
+
+    if (commerceReviews.length && ((prevProps.loading && !loading) || (prevProps.refreshing && !refreshing))) {
+      this.setState({ lastVisible: commerceReviews[commerceReviews.length - 1].date.toDate() });
+    }
+  }
+
+  loadMoreReviews = () => {
+    this.props.onCommerceReviewsRead(this.props.navigation.state.params.commerceId, this.state.lastVisible);
+  }
+
+  renderFooter = () => {
+    if (this.props.moreData)
+      return (
+        <Button
+          title='Cargar más'
+          type='clear'
+          loading={this.props.refreshing}
+          onPress={this.loadMoreReviews}
+        />
+      );
+
+    return null;
   }
 
   renderItem = ({ item }) => {
@@ -18,16 +46,22 @@ class CommerceReviewsList extends Component {
     return this.props.loading ? (
       <Spinner />
     ) : this.props.commerceReviews && this.props.commerceReviews.length ? (
-      <FlatList data={this.props.commerceReviews} renderItem={this.renderItem} keyExtractor={review => review.id} />
+      <FlatList
+        data={this.props.commerceReviews}
+        renderItem={this.renderItem}
+        keyExtractor={review => review.id}
+        ListFooterComponent={this.renderFooter()}
+        refreshing={this.props.refreshing}
+      />
     ) : (
-      <EmptyList title="Parece que no hay reseñas" />
-    );
+          <EmptyList title="Parece que no hay reseñas" />
+        );
   }
 }
 
 const mapStateToProps = state => {
-  const { loading, commerceReviews } = state.commerceReviewsList;
-  return { loading, commerceReviews };
+  const { loading, commerceReviews, refreshing, moreData } = state.commerceReviewsList;
+  return { loading, commerceReviews, refreshing, moreData };
 };
 
 export default connect(mapStateToProps, { onCommerceReviewsRead })(CommerceReviewsList);

--- a/src/components/CommerceReviewsList.js
+++ b/src/components/CommerceReviewsList.js
@@ -43,19 +43,20 @@ class CommerceReviewsList extends Component {
   };
 
   render() {
-    return this.props.loading ? (
-      <Spinner />
-    ) : this.props.commerceReviews && this.props.commerceReviews.length ? (
-      <FlatList
-        data={this.props.commerceReviews}
-        renderItem={this.renderItem}
-        keyExtractor={review => review.id}
-        ListFooterComponent={this.renderFooter()}
-        refreshing={this.props.refreshing}
-      />
-    ) : (
-          <EmptyList title="Parece que no hay reseñas" />
-        );
+    if (this.props.loading) return <Spinner />;
+
+    if (this.props.commerceReviews && this.props.commerceReviews.length)
+      return (
+        <FlatList
+          data={this.props.commerceReviews}
+          renderItem={this.renderItem}
+          keyExtractor={review => review.id}
+          ListFooterComponent={this.renderFooter()}
+          refreshing={this.props.refreshing}
+        />
+      )
+
+    return <EmptyList title="Parece que no hay reseñas" />
   }
 }
 

--- a/src/components/client/ClientReservationsList.js
+++ b/src/components/client/ClientReservationsList.js
@@ -30,13 +30,13 @@ class ClientReservationsList extends Component {
 
     this.props.reservations.forEach(res => {
       if (res.endDate < moment()) {
-        pastList.push(res);
+        pastList.unshift(res);
       } else {
         nextList.push(res);
       }
     })
 
-    return [pastList.reverse(), nextList];
+    return [pastList, nextList];
   };
 
   onRefresh = () => {

--- a/src/components/commerce/CommerceReservationsList.js
+++ b/src/components/commerce/CommerceReservationsList.js
@@ -50,7 +50,7 @@ class CommerceReservationsList extends Component {
 
     this.props.reservations.forEach(res => {
       if (res.endDate < moment()) {
-        pastList.push(res);
+        pastList.unshift(res);
       } else if (res.startDate <= moment() && res.endDate >= moment()) {
         currentList.push(res);
       } else {
@@ -58,7 +58,7 @@ class CommerceReservationsList extends Component {
       }
     });
 
-    return [pastList.reverse(), currentList, nextList];
+    return [pastList, currentList, nextList];
   }
 
   onEmployeesFilterValueChange = selectedEmployeeId => {
@@ -122,7 +122,7 @@ class CommerceReservationsList extends Component {
     return (
       <View style={{
         flexDirection: 'row',
-        alignSelf: 'center'
+        alignItems: 'center'
       }}
       >
         <Text style={{

--- a/src/components/commerce/CommerceReservationsList.js
+++ b/src/components/commerce/CommerceReservationsList.js
@@ -12,7 +12,6 @@ class CommerceReservationsList extends Component {
   state = {
     selectedDate: moment(),
     selectedIndex: 1,
-    filteredList: [],
     selectedReservation: {},
     detailsVisible: false,
     selectedEmployeeId: this.props.selectedEmployeeId
@@ -24,12 +23,6 @@ class CommerceReservationsList extends Component {
     this.willFocusSubscription = this.props.navigation.addListener('willFocus', () =>
       this.onEmployeesFilterValueChange(this.props.selectedEmployeeId)
     );
-  }
-
-  componentDidUpdate(prevProps) {
-    if (prevProps.reservations !== this.props.reservations) {
-      this.updateIndex(this.state.selectedIndex);
-    }
   }
 
   componentWillUnmount() {
@@ -50,23 +43,23 @@ class CommerceReservationsList extends Component {
     this.setState({ selectedDate });
   };
 
-  updateIndex = selectedIndex => {
-    const { reservations } = this.props;
-    let filteredList = [];
+  filterLists = () => {
+    const pastList = [];
+    const currentList = [];
+    const nextList = [];
 
-    if (selectedIndex == 0) {
-      // turnos pasados
-      filteredList = reservations.filter(res => res.endDate < moment()).reverse();
-    } else if (selectedIndex == 1) {
-      // turnos en curso
-      filteredList = reservations.filter(res => res.startDate <= moment() && res.endDate >= moment());
-    } else {
-      // turnos próximos
-      filteredList = reservations.filter(res => res.startDate > moment());
-    }
+    this.props.reservations.forEach(res => {
+      if (res.endDate < moment()) {
+        pastList.push(res);
+      } else if (res.startDate <= moment() && res.endDate >= moment()) {
+        currentList.push(res);
+      } else {
+        nextList.push(res);
+      }
+    });
 
-    this.setState({ filteredList, selectedIndex });
-  };
+    return [pastList.reverse(), currentList, nextList];
+  }
 
   onEmployeesFilterValueChange = selectedEmployeeId => {
     if (selectedEmployeeId && selectedEmployeeId !== this.state.selectedEmployeeId) {
@@ -123,23 +116,44 @@ class CommerceReservationsList extends Component {
     );
   };
 
-  renderList = () => {
-    const { filteredList } = this.state;
+  getButton = ({ title, listLength, listIndex }) => {
+    const isSelected = listIndex === this.state.selectedIndex;
 
-    if (filteredList.length) {
-      return (
-        <FlatList
-          data={filteredList}
-          renderItem={this.renderItem.bind(this)}
-          keyExtractor={reservation => reservation.id}
+    return (
+      <View style={{
+        flexDirection: 'row',
+        alignSelf: 'center'
+      }}
+      >
+        <Text style={{
+          color: isSelected ? MAIN_COLOR : 'white',
+          paddingRight: 6,
+          fontSize: 12,
+          textAlignVertical: 'center'
+        }}
+        >
+          {title}
+        </Text>
+        <Badge
+          value={listLength}
+          color={isSelected ? MAIN_COLOR : 'white'}
+          textStyle={{ color: isSelected ? 'white' : MAIN_COLOR, fontSize: 12 }}
+          containerStyle={{ paddingTop: 0 }}
+          badgeStyle={{ paddingLeft: 3, paddingRight: 3, height: 21, borderRadius: 10.5 }}
         />
-      );
-    }
-
-    return <EmptyList title="No hay turnos" />;
-  };
+      </View>
+    )
+  }
 
   render() {
+    const filteredLists = this.filterLists();
+
+    const buttons = [
+      { element: () => this.getButton({ title: 'PASADOS', listLength: filteredLists[0].length, listIndex: 0 }) },
+      { element: () => this.getButton({ title: 'EN CURSO', listLength: filteredLists[1].length, listIndex: 1 }) },
+      { element: () => this.getButton({ title: 'PRÓXIMOS', listLength: filteredLists[2].length, listIndex: 2 }) }
+    ];
+
     return (
       <View style={{ alignSelf: 'stretch', flex: 1 }}>
         <AreaComponentRenderer
@@ -153,9 +167,9 @@ class CommerceReservationsList extends Component {
         <Calendar onDateSelected={date => this.onDateSelected(date)} startingDate={this.state.selectedDate} />
 
         <ButtonGroup
-          onPress={this.updateIndex}
+          onPress={selectedIndex => this.setState({ selectedIndex })}
           selectedIndex={this.state.selectedIndex}
-          buttons={['PASADOS', 'EN CURSO', 'PRÓXIMOS']}
+          buttons={buttons}
           containerBorderRadius={0}
           containerStyle={styles.buttonGroupContainerStyle}
           selectedButtonStyle={styles.buttonGroupSelectedButtonStyle}
@@ -164,7 +178,17 @@ class CommerceReservationsList extends Component {
           selectedTextStyle={styles.buttonGroupSelectedTextStyle}
           innerBorderStyle={styles.buttonGroupInnerBorderStyle}
         />
-        {this.props.loading ? <Spinner style={{ position: 'relative' }} /> : this.renderList()}
+
+        {
+          this.props.loading ? <Spinner style={{ position: 'relative' }} />
+            : filteredLists[this.state.selectedIndex].length ?
+              <FlatList
+                data={filteredLists[this.state.selectedIndex]}
+                renderItem={this.renderItem.bind(this)}
+                keyExtractor={reservation => reservation.id}
+              />
+              : <EmptyList title="No hay turnos" />
+        }
       </View>
     );
   }
@@ -172,7 +196,7 @@ class CommerceReservationsList extends Component {
 
 const styles = StyleSheet.create({
   buttonGroupContainerStyle: {
-    height: 40,
+    height: 45,
     borderRadius: 0,
     borderWidth: 0,
     borderBottomWidth: 0.5,

--- a/src/components/common/Badge.js
+++ b/src/components/common/Badge.js
@@ -5,9 +5,8 @@ import { Badge as RNEBadge } from 'react-native-elements';
 const Badge = props => {
   return (
     <RNEBadge
-      value={props.value}
-      onPress={props.onPress}
-      badgeStyle={{ ...styles.badgeStyle, backgroundColor: props.color }}
+      {...props}
+      badgeStyle={[{ ...styles.badgeStyle, backgroundColor: props.color }, props.badgeStyle]}
       containerStyle={[styles.containerStyle, props.containerStyle]}
     />
   )

--- a/src/components/common/Button.js
+++ b/src/components/common/Button.js
@@ -5,14 +5,17 @@ import { MAIN_COLOR } from '../../constants';
 
 class Button extends Component {
   render() {
-    const color = this.props.color || MAIN_COLOR;
+    const backgroundColor = this.props.type !== 'clear' ? this.props.color || MAIN_COLOR : 'white';
+    const color = this.props.type !== 'clear' ? 'white' : this.props.color || MAIN_COLOR;
 
     return (
       <View style={this.props.outerContainerStyle}>
         <RNEButton
           {...this.props}
-          buttonStyle={[styles.buttonStyle, { backgroundColor: color }, this.props.buttonStyle]}
+          buttonStyle={[styles.buttonStyle, { backgroundColor }, this.props.buttonStyle]}
           containerStyle={[styles.containerStyle, this.props.containerStyle]}
+          titleStyle={{ color }}
+          loadingProps={{ color }}
         />
       </View>
     );

--- a/src/reducers/ClientReviewsListReducer.js
+++ b/src/reducers/ClientReviewsListReducer.js
@@ -1,19 +1,22 @@
 import { ON_CLIENT_REVIEWS_READING, ON_CLIENT_REVIEWS_READ, ON_CLIENT_REVIEWS_READ_FAIL } from '../actions/types';
 import { Toast } from '../components/common';
 
-const INITIAL_STATE = { clientReviews: [], loading: true };
+const INITIAL_STATE = { clientReviews: [], loading: false, refreshing: false, moreData: false };
 
 export default (state = INITIAL_STATE, action) => {
   switch (action.type) {
     case ON_CLIENT_REVIEWS_READING:
-      return { ...state, loading: true };
+      return { ...state, [action.payload]: true };
 
     case ON_CLIENT_REVIEWS_READ:
-      return { ...state, clientReviews: action.payload, loading: false };
+      let { reviews, firstRead } = action.payload;
+      const clientReviews = firstRead ? reviews : [...state.clientReviews, ...reviews];
+
+      return { ...state, clientReviews, loading: false, refreshing: false, moreData: !!(reviews.length < 12) };
 
     case ON_CLIENT_REVIEWS_READ_FAIL:
       Toast.show({ text: 'Se ha producido un error, inténtelo de nuevo.' });
-      return { ...state, loading: false };
+      return { ...state, loading: false, refreshing: false };
 
     default:
       return state;

--- a/src/reducers/ClientReviewsListReducer.js
+++ b/src/reducers/ClientReviewsListReducer.js
@@ -12,7 +12,7 @@ export default (state = INITIAL_STATE, action) => {
       let { reviews, firstRead } = action.payload;
       const clientReviews = firstRead ? reviews : [...state.clientReviews, ...reviews];
 
-      return { ...state, clientReviews, loading: false, refreshing: false, moreData: !!(reviews.length < 12) };
+      return { ...state, clientReviews, loading: false, refreshing: false, moreData: !!(reviews.length === 12) };
 
     case ON_CLIENT_REVIEWS_READ_FAIL:
       Toast.show({ text: 'Se ha producido un error, inténtelo de nuevo.' });

--- a/src/reducers/CommerceReviewsListReducer.js
+++ b/src/reducers/CommerceReviewsListReducer.js
@@ -1,19 +1,22 @@
 import { ON_COMMERCE_REVIEWS_READING, ON_COMMERCE_REVIEWS_READ, ON_COMMERCE_REVIEWS_READ_FAIL } from '../actions/types';
 import { Toast } from '../components/common';
 
-const INITIAL_STATE = { commerceReviews: [], loading: true };
+const INITIAL_STATE = { commerceReviews: [], loading: true, refreshing: false, moreData: true };
 
 export default (state = INITIAL_STATE, action) => {
   switch (action.type) {
     case ON_COMMERCE_REVIEWS_READING:
-      return { ...state, loading: true };
+      return { ...state, [action.payload]: true };
 
     case ON_COMMERCE_REVIEWS_READ:
-      return { ...state, commerceReviews: action.payload, loading: false };
+      let { reviews, firstRead } = action.payload;
+      const commerceReviews = firstRead ? reviews : [...state.commerceReviews, ...reviews];
+
+      return { ...state, commerceReviews, loading: false, refreshing: false, moreData: !!reviews.length };
 
     case ON_COMMERCE_REVIEWS_READ_FAIL:
       Toast.show({ text: 'Se ha producido un error, inténtelo de nuevo.' });
-      return { ...state, loading: false };
+      return { ...state, loading: false, refreshing: false };
 
     default:
       return state;

--- a/src/reducers/CommerceReviewsListReducer.js
+++ b/src/reducers/CommerceReviewsListReducer.js
@@ -1,7 +1,7 @@
 import { ON_COMMERCE_REVIEWS_READING, ON_COMMERCE_REVIEWS_READ, ON_COMMERCE_REVIEWS_READ_FAIL } from '../actions/types';
 import { Toast } from '../components/common';
 
-const INITIAL_STATE = { commerceReviews: [], loading: true, refreshing: false, moreData: true };
+const INITIAL_STATE = { commerceReviews: [], loading: false, refreshing: false, moreData: true };
 
 export default (state = INITIAL_STATE, action) => {
   switch (action.type) {
@@ -12,7 +12,7 @@ export default (state = INITIAL_STATE, action) => {
       let { reviews, firstRead } = action.payload;
       const commerceReviews = firstRead ? reviews : [...state.commerceReviews, ...reviews];
 
-      return { ...state, commerceReviews, loading: false, refreshing: false, moreData: !!reviews.length };
+      return { ...state, commerceReviews, loading: false, refreshing: false, moreData: !!(reviews.length < 12) };
 
     case ON_COMMERCE_REVIEWS_READ_FAIL:
       Toast.show({ text: 'Se ha producido un error, inténtelo de nuevo.' });

--- a/src/reducers/CommerceReviewsListReducer.js
+++ b/src/reducers/CommerceReviewsListReducer.js
@@ -12,7 +12,7 @@ export default (state = INITIAL_STATE, action) => {
       let { reviews, firstRead } = action.payload;
       const commerceReviews = firstRead ? reviews : [...state.commerceReviews, ...reviews];
 
-      return { ...state, commerceReviews, loading: false, refreshing: false, moreData: !!(reviews.length < 12) };
+      return { ...state, commerceReviews, loading: false, refreshing: false, moreData: !!(reviews.length === 12) };
 
     case ON_COMMERCE_REVIEWS_READ_FAIL:
       Toast.show({ text: 'Se ha producido un error, inténtelo de nuevo.' });


### PR DESCRIPTION
Lo que hice aca es agregar un boton que te permita en los listados de calificaciones, ir cargando mas calificaciones al ir scrolleando, porque cuando generé datos de prueba, cargue una banda de calificaciones, y no daba cargar todas de una. Puse el boton en vez de hacer que la carga sea automaticamente al ir scrolleando porque andaba medio mal de esa forma.

A eso tambien lo iba a hacer en el listado de reservas del cliente y en los listados de notificaciones, pero ahi no se me ocurrio bien como hacerlo por ahora, porque en esos casos se usa onSnapshot, en cambio en el listado de calificaciones se usan consultas comunes. Por ahora en esos listados que usan onSnapshot unicamente les puse un .limit() para que traiga nomas lo mas reciente.

De paso agregue tambien una sugerencia que tiro manolo, de poner contadores de turnos en las pestañas del listado de turnos del negocio (Pasados, En Curso, Proximos). Tambien pense de agregarlo en el listado de reservas del cliente, pero al final me parecio que era al pedo, porque el cliente es muy raro que tenga muchas reservas en Proximos, y tampoco veo porque querria saber la cantidad de turnos Pasados, y ademas como esa consulta tiene un .limit(), entonces la cantidad de turnos pasados no seria real.

Fijense que onda, si vemos que esta todo bien y no hay bugs lo mergeo.